### PR TITLE
Atualiza a imagem base do Docker para postgres:18.1-bookworm e corrige o caminho do volume no docker-compose.yml

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile.database
-FROM postgres:18.3
+FROM postgres:18.1-bookworm
 
 COPY ./src /scripts/src
 COPY ./install /scripts/install

--- a/database/docker-compose.yml
+++ b/database/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - database-data:/var/lib/postgresql/data
+      - database-data:/var/lib/postgresql
     mem_limit: 512m
     cpus: '0.25'
 


### PR DESCRIPTION
# 🚀 Título do PR / PR Title

## 📝 Descrição das Mudanças / Change Description

Mudanças no postgres 18+ alteraram a forma onde o volume armazena os dados, sendo preciso alterar nos repos que usam isso